### PR TITLE
Fix PHP Warnings

### DIFF
--- a/classes/ezdbischemachecker.php
+++ b/classes/ezdbischemachecker.php
@@ -269,9 +269,9 @@ class ezdbiSchemaChecker extends ezdbiBaseChecker
         if ( $childTable == $parentTable) {
             $childTableFull = $childTable . " child";
             $parentTableFull = $parentTable . " parent";
+            $exceptions = $this->rewriteExceptionsQueryFragment( $exceptions, $childTable, $childCol, $parentTable, $parentCol );
             $childTable = 'child';
             $parentTable = 'parent';
-            $exceptions = $this->rewriteExceptionsQueryFragment( $exceptions, $childTable, $childCol, $parentTable, $parentCol );
         } else {
             $childTableFull = $childTable;
             $parentTableFull = $parentTable;
@@ -295,9 +295,9 @@ class ezdbiSchemaChecker extends ezdbiBaseChecker
         if ( $childTable == $parentTable) {
             $childTableFull = $childTable . " child";
             $parentTableFull = $parentTable . " parent";
+            $exceptions = $this->rewriteExceptionsQueryFragment( $exceptions, $childTable, $childCol, $parentTable, $parentCol );
             $childTable = 'child';
             $parentTable = 'parent';
-            $exceptions = $this->rewriteExceptionsQueryFragment( $exceptions, $childTable, $childCol, $parentTable, $parentCol );
         } else {
             $childTableFull = $childTable;
             $parentTableFull = $parentTable;
@@ -386,12 +386,12 @@ class ezdbiSchemaChecker extends ezdbiBaseChecker
 
         foreach( $childCols as $i => $childCol )
         {
-            $exceptions = str_replace($childTable . '.' . $childCol, 'child.' . $childCol );
+            $exceptions = str_replace($childTable . '.' . $childCol, 'child.' . $childCol, $exceptions );
         }
 
         foreach( $parentCols as $i => $parentCol )
         {
-            $exceptions = str_replace($parentTable . '.' . $parentCol, 'parent.' . $parentCol );
+            $exceptions = str_replace($parentTable . '.' . $parentCol, 'parent.' . $parentCol, $exceptions );
         }
 
         return $exceptions;

--- a/classes/ezdbischemachecker.php
+++ b/classes/ezdbischemachecker.php
@@ -200,7 +200,7 @@ class ezdbiSchemaChecker extends ezdbiBaseChecker
             $parentCols = $parentCol;
         }
 
-        $diffs = null;
+        $diffs = array();
 
         if ( count( $childCols) != count( $parentCols ) )
         {


### PR DESCRIPTION
I get following warnings if I run `php extension/ezdbintegrity/bin/php/checkschema.php`
```
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in extension/ezdbintegrity/classes/ezdbischemachecker.php on line 222
```
```
PHP Warning: str_replace() expects at least 3 parameters, 2 given in extension/ezdbintegrity/classes/ezdbischemachecker.php on line 394
```