### PR TITLE
Skip image variations

### DIFF
--- a/classes/ezdbistoragecker.php
+++ b/classes/ezdbistoragecker.php
@@ -90,7 +90,7 @@ class ezdbiStorageChecker extends ezdbiBaseChecker
             $files = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $dir ) );
             foreach ($files as $storageFileName => $storageFileInfo )
             {
-                if ( $storageFileInfo->isDir() )
+                if ( $storageFileInfo->isDir() || strpos( $storageFileName, $pDir . '/_aliases/' ) === 0 )
                 {
                     continue;
                 }


### PR DESCRIPTION
I think the checkstorage.php command should ignore variations. The command will delete all variation because there are not in the ezimagefile db table.
When someone want delete all variations, he should use the liip:imagine:cache:remove command.